### PR TITLE
New aws-credentials syntax and warning message

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ The generated **jFaaS-all.jar** file can be found in the **build/libs/** folder.
 
 #### Structure ``credentials.proporties``, which should be placed in the same folder as the **jFaaS-all.jar**:
 ````
-aws_access_key=
-aws_secret_key=
+aws_access_key_id=
+aws_secret_access_key=
 aws_session_token=              // (needed for AWS Educate)
 ibm_api_key=
 google_sa_key={\

--- a/src/main/java/jFaaS/Gateway.java
+++ b/src/main/java/jFaaS/Gateway.java
@@ -44,6 +44,12 @@ public class Gateway implements FaaSInvoker {
                 if (properties.containsKey("aws_session_token")) {
                     awsSessionToken = properties.getProperty("aws_session_token");
                 }
+            } else if (properties.containsKey("aws_access_key_id") && properties.containsKey("aws_secret_access_key")) {
+                awsAccessKey = properties.getProperty("aws_access_key_id");
+                awsSecretKey = properties.getProperty("aws_secret_access_key");
+                if (properties.containsKey("aws_session_token")) {
+                    awsSessionToken = properties.getProperty("aws_session_token");
+                }
             }
             if (properties.containsKey("ibm_api_key")) {
                 openWhiskKey = properties.getProperty("ibm_api_key");
@@ -59,7 +65,10 @@ public class Gateway implements FaaSInvoker {
 
             if (properties.containsKey("azure_key")) {
                 azureKey = properties.getProperty("azure_key");
+            }
 
+            if(awsAccessKey == null && openWhiskKey == null && googleServiceAccountKey == null && azureKey == null){
+                LOGGER.log(Level.WARNING, "No valid data in credentials file found.");
             }
 
         } catch (IOException e) {


### PR DESCRIPTION
Changes proposed in this pull request:

- Added the current aws-credentials syntax to be used in the credentials.properties (the old syntax is still usable)
- Added warning-message to inform the user when no valid data was found in the credentials file
- Updated README