### PR TITLE
Feature/http post invoker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,11 @@
                     <target>8</target>
                 </configuration>
             </plugin>
+              <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <version>3.0.0-M5</version>
+              </plugin>
         </plugins>
     </build>
 
@@ -81,7 +86,24 @@
             <artifactId>google-cloud-iamcredentials</artifactId>
             <version>1.1.7</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+    </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>4.6.1</version>
+            <scope>test</scope>
+        </dependency>
 
 
     </dependencies>

--- a/src/main/java/jFaaS/Gateway.java
+++ b/src/main/java/jFaaS/Gateway.java
@@ -27,6 +27,7 @@ public class Gateway implements FaaSInvoker {
     private FaaSInvoker azureInvoker;
     private String azureKey;
     private FaaSInvoker httpGETInvoker;
+    private HTTPPOSTInvoker httpPOSTInvoker;
     private VMInvoker vmInvoker;
 
     /**
@@ -66,7 +67,7 @@ public class Gateway implements FaaSInvoker {
             LOGGER.log(Level.WARNING, "Could not load credentials file.");
         }
         httpGETInvoker = new HTTPGETInvoker();
-
+        httpPOSTInvoker = new HTTPPOSTInvoker();
     }
 
 
@@ -75,8 +76,19 @@ public class Gateway implements FaaSInvoker {
      */
     public Gateway() {
         httpGETInvoker = new HTTPGETInvoker();
+        httpPOSTInvoker = new HTTPPOSTInvoker();
     }
 
+    /**
+     * Gateway for constructer based dependency injection
+     *
+     * @param httpPOSTInvoker
+     * @param httpGETInvoker
+     */
+    public Gateway(HTTPGETInvoker httpGETInvoker, HTTPPOSTInvoker httpPOSTInvoker) {
+        this.httpGETInvoker = httpGETInvoker;
+        this.httpPOSTInvoker = httpPOSTInvoker;
+    }
     /**
      * Detect aws lambda region
      *
@@ -170,6 +182,12 @@ public class Gateway implements FaaSInvoker {
         } else if (function.contains("fc.aliyuncs.com")) {
             // TODO check for alibaba authentication. Currently no authentication is assumed
             return httpGETInvoker.invokeFunction(function, functionInputs);
+        } else if (function.startsWith("HTTP_GET:")) {
+            String url = function.split(":", 2)[1];
+            return httpGETInvoker.invokeFunction(url, functionInputs);
+        } else if (function.startsWith("HTTP_POST:")) {
+            String url = function.split(":", 2)[1];
+            return httpPOSTInvoker.invokeFunction(url, functionInputs);
         } else if (function.contains(":VM:")) {
             if (vmInvoker == null) {
                 vmInvoker = new VMInvoker();

--- a/src/main/java/jFaaS/invokers/HTTPPOSTInvoker.java
+++ b/src/main/java/jFaaS/invokers/HTTPPOSTInvoker.java
@@ -1,0 +1,60 @@
+package jFaaS.invokers;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
+import jFaaS.utils.PairResult;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+
+public class HTTPPOSTInvoker implements FaaSInvoker {
+    public HTTPPOSTInvoker() {
+        System.setProperty("https.protocols", "TLSv1.2");
+    }
+
+    /**
+     * Makes a HTTP POST request.
+     *
+     * @return
+     */
+    @Override
+    public PairResult<String, Long> invokeFunction(String function, Map<String, Object> parameters) throws IOException {
+        long start = System.currentTimeMillis();
+
+        URL obj = new URL(function);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+
+        Gson gson = new Gson();
+        Type gsonType = new TypeToken<Map<String, Object>>(){}.getType();
+        String requestBody = gson.toJson(parameters,gsonType);
+
+        con.setRequestMethod("POST");
+        con.setRequestProperty("Content-Type", "application/json");
+
+        // why?
+        con.setRequestProperty("User-Agent", "Mozilla/5.0");
+        con.setRequestProperty("Accept", "application/json");
+        con.setDoOutput(true);
+        OutputStream os = con.getOutputStream();
+        os.write(requestBody.getBytes("utf-8"), 0, requestBody.length());
+        os.flush();
+        os.close();
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuilder response = new StringBuilder();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return new PairResult<>(new Gson().fromJson(response.toString(), JsonObject.class).getAsJsonObject().toString(), System.currentTimeMillis() - start);
+
+    }
+}

--- a/src/test/java/GatewayTests.java
+++ b/src/test/java/GatewayTests.java
@@ -1,0 +1,50 @@
+import jFaaS.Gateway;
+import jFaaS.invokers.HTTPGETInvoker;
+import jFaaS.invokers.HTTPPOSTInvoker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@ExtendWith(MockitoExtension.class)
+public class GatewayTests {
+
+    @Mock
+    public static HTTPPOSTInvoker httpPOSTInvoker;
+
+    @Mock
+    public static HTTPGETInvoker httpGETInvoker;
+
+    @InjectMocks
+    public static Gateway gateway;
+
+
+    @Test
+    public void testHTTPPOSTInvocation() throws IOException {
+        Map<String, Object> params = new HashMap<String, Object>();
+        gateway.invokeFunction("HTTP_POST:https://foo.bar/api/v1/items", params);
+        Mockito.verify(httpPOSTInvoker).invokeFunction(Mockito.eq("https://foo.bar/api/v1/items"),
+                Mockito.anyMap());
+    }
+
+    @Test void testHTTPGETInvocation() throws IOException {
+        Map<String, Object> params = new HashMap<String, Object>();
+        gateway.invokeFunction("HTTP_GET:https://foo.bar/api/v1/items", params);
+        Mockito.verify(httpGETInvoker).invokeFunction(Mockito.eq("https://foo.bar/api/v1/items"),
+                Mockito.anyMap());
+    }
+
+    @Test void testAlibabaInvocation() throws IOException {
+        String endpoint = "164901546557.cn-shanghai.fc.aliyuncs.com/2016-08-15/proxy/serviceName/functionName/";
+        Map<String, Object> params = new HashMap<String, Object>();
+        gateway.invokeFunction(endpoint, params);
+        Mockito.verify(httpGETInvoker).invokeFunction(Mockito.eq(endpoint),
+                Mockito.anyMap());
+    }
+}


### PR DESCRIPTION
### HTTP Post Invoker

This new type of invoker can be used to invoke web services or functions with a post request. 

The service url is specified via the resource property with the HTTP_POST prefix: 
```yaml
properties:
    - name: "resource"
      value: "HTTP_POST:https://example.service/api/v3/service"
```

This change also include introduces unit tests (only for this feature for now). 